### PR TITLE
Test Node Multiplicity

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,0 @@
-# Description
-Please include a summary of the change relevant motivation and context. Ensure the PR name is associated to the Jira issue that is being resolved (i.e. RT-XXX CI Fix) and that the issue is linked below. Explicitly list any dependencies that are required for this change.
-
-Fixes:
- - Include link to Jira issue here
- 
-# Merge Summary:
-- [ ] List checklist items here for PR tracking

--- a/inventory/group_vars/gar.yaml
+++ b/inventory/group_vars/gar.yaml
@@ -2,4 +2,4 @@
 # action runner configurables
 runner_tag: tests
 # teardown
-teardown: false 
+teardown: false

--- a/inventory/group_vars/gar.yaml
+++ b/inventory/group_vars/gar.yaml
@@ -1,0 +1,5 @@
+---
+# action runner configurables
+runner_tag: tests
+# teardown
+teardown: false 

--- a/inventory/group_vars/tests.yaml
+++ b/inventory/group_vars/tests.yaml
@@ -1,6 +1,0 @@
----
-# action runner configurables
-runner_name: iris-tests
-runner_tag: tests
-# teardown
-teardown: false

--- a/playbooks/iris-tests.yaml
+++ b/playbooks/iris-tests.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Setup Tests CI Server
-  hosts: gar 
+  hosts: gar
   pre_tasks:
     # apt housekeeping
     - name: Update and upgrade apt packages

--- a/playbooks/iris-tests.yaml
+++ b/playbooks/iris-tests.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Setup Tests CI Server
-  hosts: iris-tests
+  hosts: gar 
   pre_tasks:
     # apt housekeeping
     - name: Update and upgrade apt packages

--- a/roles/actions/handlers/main.yaml
+++ b/roles/actions/handlers/main.yaml
@@ -5,5 +5,5 @@
 
 - name: verify
   service:
-    name: "actions.runner.{{ organization }}.{{ runner_name }}.service"
+    name: "actions.runner.{{ organization }}.{{ ansible_host }}.service"
     state: started

--- a/roles/actions/tasks/deploy.yaml
+++ b/roles/actions/tasks/deploy.yaml
@@ -71,7 +71,7 @@
     command: >
       {{ actions_runner }}/config.sh --url {{ organization_url }} --token {{ runner_token.json.token }}
     responses:
-      (.*)Enter the name of runner:(.*): "{{ runner_name }}"
+      (.*)Enter the name of runner:(.*): "{{ ansible_host }}"
       (.*)Enter any additional labels \(ex. label-1,label-2\):(.*): "{{ runner_tag }}"
       (.*)Enter name of work folder:(.*): "{{ gar_work_folder }}"
       (.*)Would you like to replace the existing runner? (Y/N)(.*): ""

--- a/roles/actions/vars/main.yaml
+++ b/roles/actions/vars/main.yaml
@@ -13,4 +13,4 @@ gar_work_folder: work
 github_base_path: "https://api.github.com"
 organization: Incuvers
 organization_url: "https://github.com/{{ organization }}"
-service_name: "actions.runner.{{ organization }}.{{ runner_name }}.service"
+service_name: "actions.runner.{{ organization }}.{{ ansible_host }}.service"


### PR DESCRIPTION
# Description
Update deployment and teardown for ci nodes to allow for multiple github action runner replicas to exist on different nodes.
 
# Merge Summary:
- [x] remove old or template (ref from .github repo)
- [x] update `runner_name` to match `ansible_host` to allow for multiplicity